### PR TITLE
Adjusted Internal-embed:not CSS Styling for improved padding on bases embed

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -709,7 +709,7 @@ body {
   border: 1px solid var(--color-base-25);
   border-top-color: var(--color-base-30);
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
-  padding: 0.5rem 1em 0;
+  padding: 0.5rem 1em 1em;
 }
 
 .embed-title {


### PR DESCRIPTION
Adjusted the Internal-embed:not css class for an improved viewing experience on bases:
Before:
<img width="963" height="158" alt="image" src="https://github.com/user-attachments/assets/69478f9e-3464-43ec-9d89-7b583d4fc161" />

After:
<img width="953" height="153" alt="image" src="https://github.com/user-attachments/assets/25d74eff-a129-4c26-aef4-08b1d8bdfbf9" />

